### PR TITLE
Dev/bump meteor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: lunafi/slim-meteord
     environment:
-      - NODE_VER: "893"
+      - NODE_VER: "894"
       - AWS_CLI_VER: "11416"
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 # Node version needs to match meteor node -v
-FROM mhart/alpine-node:8.9.3
+FROM mhart/alpine-node:8.9.4
 
 ARG AWS_CLI_VERSION_DOWNLOAD=1.14.16
 
-ARG DOCKER_COMPOSE_VERSION_DOWNLOAD=1.18.0
-ARG DOCKER_VERSION=17.05.0-r0
-#The above DOCKER is used for CI builds.
+
+#DOCKER is used for CI builds.
 #It was a compromise for not having sudo and adds ~100 MB
 
 # Install the AWS CLI and Docker Compose
 RUN apk --no-cache update && \
     apk --no-cache -Uuv add bash python py-pip ca-certificates \
-    docker=${DOCKER_VERSION} \
+    docker \
     curl libstdc++ g++ make && \
     pip --no-cache-dir install awscli==${AWS_CLI_VERSION_DOWNLOAD} \
-    docker-compose==${DOCKER_COMPOSE_VERSION_DOWNLOAD} && \
+    docker-compose && \
     apk --purge -v del py-pip && \
     rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 This image was built (~300MB) for running a slim version of Meteor and locking in a specific node version for custom deployment to AWS. 
 
-* Node Version is locked at v8.9.3
-* Server is expecting the bundle was built from Meteor 1.6.1
+* Node Version is locked at v8.9.4
+* Server is expecting the bundle was built from Meteor 1.6.1.1
 * AWS CLI is locked at 1.14.16 (so you can retrieve secrets from S3 or push to ECS)
 
-Note: It also includes Docker-compose 1.18.0 and Docker 17.05.0-r0 (so it could easily be used as a base image in CI jobs)
+Note: It also includes Docker-compose >= 1.18.0 and Docker >= 17.05.0-r0 (so it could easily be used as a base image in CI jobs)


### PR DESCRIPTION
bumping node version
removed docker versions (as alpine prunes their packages and so sticky on them makes it hard)